### PR TITLE
Add page for pldi 2022 egraphs workshop

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,16 +95,10 @@
         <li><a href="https://github.com/egraphs-good/egg">GitHub</a></li>
         <li><a href="https://docs.rs/egg">Documentation</a></li>
         <li><a href="https://github.com/egraphs-good/egg/discussions">Blog &amp; Discussion</a></li>
+        <li><a href="workshop/2022.html">Workshop</a></li>
       </ul>
     </nav>
   </div>
-
-  <p style="text-align: center; font-weight: bold;">
-    Check out the <a href="https://pldi22.sigplan.org/home/egraphs-2022">EGRAPHS Workshop</a>
-    and
-    <a href="https://pldi22.sigplan.org/details/pldi-2022-tutorials/6/Build-your-own-optimizer-with-egg-">Tutorial</a>
-    at <a href="https://pldi22.sigplan.org/">PLDI 2022</a>!
-  </p>
 
   <p>
     The <span class="egg">egg</span> project uses e-graphs

--- a/workshop.html
+++ b/workshop.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>egg</title>
+  <meta name="description" content="'egg' is an open-source, high performance e-graph and equality saturation toolkit.">
+  <link rel="icon" type="image/svg+xml" href="/egg.svg">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Coming+Soon" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans" rel="stylesheet">
+  <style type="text/css">
+    body {
+      background-color: papayawhip;
+      max-width: 800px;
+      font-size: 120%;
+      line-height: 1.2;
+      margin: auto;
+      padding: 20px;
+      font-family: 'Open Sans', 'Roboto', sans-serif;
+    }
+
+    h1,
+    h2 {
+      font-family: 'Coming Soon', 'Comic Sans', sans-serif;
+      font-weight: normal;
+    }
+
+    figcaption {
+      opacity: 80%;
+      font-size: 90%;
+    }
+
+    .egg {
+      font-family: 'Coming Soon', 'Comic Sans', sans-serif;
+      font-weight: bold;
+    }
+
+    .egg-letter {
+      line-height: 0.75em;
+      display: inline-block;
+      border-bottom: solid .25em #daa52099;
+    }
+
+    .word {
+      white-space: nowrap
+    }
+
+    .venue::before {
+      content: "["
+    }
+
+    .venue::after {
+      content: "]"
+    }
+
+    .venue {
+      opacity: 80%;
+      white-space: nowrap;
+    }
+
+    footer {
+      font-size: 60%;
+      opacity: 80%;
+      margin-top: 2em;
+      text-align: center;
+    }
+
+    nav ul {
+      list-style: none
+    }
+
+    nav ul li {
+      display: inline-block;
+      padding: 10px;
+    }
+    .schedule h3 { margin: .5em 0 0; }
+    .schedule p  { margin: 0; }
+    .schedule .affiliation {font-style: italic;  color: #666; font-size: smaller;}
+  </style>
+</head>
+
+<body>
+  <div style="text-align: center">
+    <h1 style="vertical-align: middle">
+      <img style="display: inline; vertical-align: middle;" src="egg.svg">
+      <span class="egg">egg</span>:
+      <span class="word">
+        <span class='egg-letter'>e</span>-<span class='egg-letter'>g</span>raphs
+      </span>
+      <span class="word">
+        <span class='egg-letter'>g</span>ood
+      </span>
+    </h1>
+  </div>
+
+  <p>
+    The EGRAPHS Workshop was held at <a href="https://pldi22.sigplan.org/">PLDI 2022</a>.
+  </p>
+
+  <div class="schedule">
+    <h2>Day 1</h2>
+      <h3>Sketch-Guided Equality Saturation</h3>
+      <p>Thomas Koehler <span class="affiliation">University of Glasgow</span></p>
+      <a href="https://arxiv.org/abs/2111.13040">Pre-print</a>
+
+      <h3>Synthesizing Mathematical Identities with E-Graphs</h3>
+      <p>
+        Ian Briggs <span class="affiliation">University of Utah</span>,
+        Pavel Panchekha <span class="affiliation">University of Utah</span>
+      </p>
+      <a href="https://dl.acm.org/doi/10.1145/3520308.3534506">Paper</a>
+      
+      <h3>Logging an Egg: Datalog on E-Graphs</h3>
+      <p>Philip Zucker <span class="affiliation">Draper Laboratory</span></p>
+      <a href="https://github.com/philzook58/egglog0-talk/raw/main/out.pdf">Pre-print</a>
+
+      <h3>Chasing an egg</h3>
+      <p>Yihong Zhang <span class="affiliation">University of Washington</span></p>
+      <a href="https://effect.systems/doc/pldi-2022-egraphs/abstract.pdf">Pre-print</a>
+
+      <h3>ECTAs: E-Graphs Better (at Encoding)</h3>
+      <p>
+        James Koppel <span class="affiliation">Massachusetts Institute of Technology</span>,
+        Zheng Guo <span class="affiliation">University of California, San Diego</span>,
+        Edsko de Vries <span class="affiliation">Well-Typed LLP</span>,
+        Armando Solar-Lezama <span class="affiliation">Massachusetts Institute of Technology</span>,
+        Nadia Polikarpova <span class="affiliation">University of California, San Diego</span>
+      </p>
+
+      <h3>E-Graphs, VSAs, and Tree Automata: a Rosetta Stone</h3>
+      <p>
+        Yisu Remy Wang <span class="affiliation">University of Washington</span>,
+        James Koppel <span class="affiliation">Massachusetts Institute of Technology</span>,
+        Altan Haan <span class="affiliation">OctoML</span>,
+        Josh Pollock <span class="affiliation">MIT CSAIL</span>
+      </p>
+      <a href="https://remy.wang/reports/dfta.pdf">Pre-print</a>
+
+      <h3>Equality Saturation as a Tactic for Proof Assistants</h3>
+      <p>
+        Andrés Goens <span class="affiliation">University of Edinburgh</span>,
+        Siddharth Bhat <span class="affiliation">University of Edinburgh</span>
+      </p>
+      
+      <h3>Towards Optimising Certified Programs by Proof Rewriting</h3>
+      <p>
+        Kiran Gopinathan <span class="affiliation">National University of Singapore</span>,
+        Ilya Sergey <span class="affiliation">National University of Singapore</span>
+      </p>
+  
+    <h2>Day 2</h2>
+      <h3>Quiche: A Python Implementation of E-Graphs</h3>
+      <p>Rebecca Swords</p>
+      
+      <h3>Optimizing Large Integer Multiplier on FPGAs Using Equality Saturation</h3>
+      <p>
+        Ecenur Ustun <span class="affiliation">Cornell University</span>,
+        Jiaqi Yin <span class="affiliation">University of Utah</span>,
+        Zhiru Zhang <span class="affiliation">Cornell University</span>
+      </p>
+      
+      <h3>Wasm-mutate: Fuzzing WebAssembly Compilers with E-Graphs</h3>
+      <p>
+        Javier Cabrera Arteaga <span class="affiliation">KTH Royal Institute of Technology</span>,
+        Nicholas Fitzgerald <span class="affiliation">Fastly Inc.</span>,
+        Martin Monperrus <span class="affiliation">KTH Royal Institute of Technology</span>,
+        Benoit Baudry <span class="affiliation">KTH</span>
+      </p>
+      <a href="https://www.jacarte.me/assets/pdf/wasm_mutate.pdf">Pre-print</a>
+      
+      <h3>QuEgg: Automatic Optimization of Quantum Circuits Using Equality Graphs</h3>
+      <p>Spencer King</p>
+      
+      <h3>On the Optimization of Equivalent Concurrent Computations</h3>
+      <p>
+        Henrich Lauko <span class="affiliation">Trail of Bits</span>,
+        Lukáš Korenčik <span class="affiliation">Trail of Bits</span>,
+        Peter Goodman <span class="affiliation">Trail of Bits</span>
+      </p>
+      
+      <h3>Abstract Interpretation on E-Graphs</h3>
+      <p>
+        Samuel Coward <span class="affiliation">Imperial College London</span>,
+        George A. Constantinides <span class="affiliation">Imperial College London</span>,
+        Theo Drane <span class="affiliation">Intel Corporation</span>
+      </p>
+      <a href="https://arxiv.org/abs/2203.09191">Pre-print</a>
+      
+      <h3>Colored E-Graph> Supporting Multiple Equivalence Relations with Resource Sharing</h3>
+      <p>
+        Eytan Singher <span class="affiliation">Technion</span>,
+        Shachar Itzhaky <span class="affiliation">Technion</span>
+      </p>
+      
+      <h3>Toward a Unified Framework for Program Optimization, Bug-Finding, and Repair</h3>
+      <p>
+        Jordan Schmerge <span class="affiliation">Colorado School of Mines</span>,
+        Jake Vossen <span class="affiliation">Colorado School of Mines</span>,
+        Jedidiah McClurg <span class="affiliation">Colorado School of Mines</span>
+      </p>
+      
+  </div>
+
+
+  <footer>
+    View or edit this site on <a href="https://github.com/egraphs-good/egraphs-good.github.io">GitHub</a>.
+  </footer>
+</body>
+
+</html>

--- a/workshop/2022.html
+++ b/workshop/2022.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>egg</title>
   <meta name="description" content="'egg' is an open-source, high performance e-graph and equality saturation toolkit.">
-  <link rel="icon" type="image/svg+xml" href="/egg.svg">
+  <link rel="icon" type="image/svg+xml" href="../egg.svg">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Coming+Soon" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans" rel="stylesheet">
@@ -84,7 +84,7 @@
 <body>
   <div style="text-align: center">
     <h1 style="vertical-align: middle">
-      <img style="display: inline; vertical-align: middle;" src="egg.svg">
+      <img style="display: inline; vertical-align: middle;" src="../egg.svg">
       <span class="egg">egg</span>:
       <span class="word">
         <span class='egg-letter'>e</span>-<span class='egg-letter'>g</span>raphs


### PR DESCRIPTION
Adds a link to the main page for the workshop and removes the workshop/tutorial at pldi announcement
Before
<img width="588" alt="image" src="https://user-images.githubusercontent.com/8787187/177854078-cdb22e4c-c2bb-4dfc-9e14-18ae6403cffc.png">
After
<img width="783" alt="image" src="https://user-images.githubusercontent.com/8787187/177853842-69bed3d4-bf96-41c6-b209-3b046fdf263e.png">

Workshop page has information and links for all the talks
<img width="601" alt="image" src="https://user-images.githubusercontent.com/8787187/177853948-a86eebbd-433b-4fa1-b109-67422b0e451c.png">
