### PR TITLE
Fix workshop link in header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
         <li><a href="https://github.com/egraphs-good/egg">GitHub</a></li>
         <li><a href="https://docs.rs/egg">Documentation</a></li>
         <li><a href="https://github.com/egraphs-good/egg/discussions">Blog &amp; Discussion</a></li>
-        <li><a href="workshop">Workshop</a></li>
+        <li><a href="/workshop">Workshop</a></li>
         <li><a href="https://egraphs.zulipchat.com">E-graphs Zulip</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Make it site-relative instead of directory-relative, otherwise it's broken on paths like `https://egraphs-good.github.io/workshop/2022`